### PR TITLE
Sync Refactoring

### DIFF
--- a/openhsr_connect/__main__.py
+++ b/openhsr_connect/__main__.py
@@ -9,6 +9,7 @@ from .exceptions import ConnectException
 from . import configuration
 from . import user_daemon
 from . import sync
+from . import smb_sync
 from . import __VERSION__
 
 logger = logging.getLogger('openhsr_connect')
@@ -59,7 +60,8 @@ def sync_command(ctx, local_changes, remote_deleted):
         ctx.obj['config']['sync']['conflict_handling']['local-changes'] = local_changes
     if remote_deleted:
         ctx.obj['config']['sync']['conflict_handling']['remote-deleted'] = remote_deleted
-    sync.sync(ctx.obj['config'])
+    smb_syncer = smb_sync.SMB_Sync(ctx.obj['config'])
+    smb_syncer.sync()
 
 
 @click.command(name='help', help="Open the Documentation in the Browser")

--- a/openhsr_connect/smb_sync.py
+++ b/openhsr_connect/smb_sync.py
@@ -1,0 +1,71 @@
+import os
+import socket
+from smb.SMBConnection import SMBConnection
+from smb.smb_structs import ProtocolError
+
+from openhsr_connect import sync
+from openhsr_connect import configuration
+from openhsr_connect import exceptions
+
+
+class SMB_Sync(sync.Sync):
+
+    SMB_SERVER_NAME = 'c206.hsr.ch'
+    SMB_SHARE_NAME = 'skripte'
+    SMB_DOMAIN = 'HSR'
+    SMB_SERVER_PORT = 445
+
+    def connect(self):
+        username = self.config['login']['username']
+        password = configuration.get_password(self.config)
+        try:
+            server_ip = socket.gethostbyname(self.SMB_SERVER_NAME)
+        except OSError as e:
+            self.logger.debug("Exception when connecting to %s: %s" % (self.SMB_SERVER_NAME, e))
+            raise exceptions.ConnectException(
+                'Could not find %s, are you in the HSR network?' % self.SMB_SERVER_NAME)
+
+        client_name = socket.gethostname()
+        connection = SMBConnection(
+            username, password, client_name,
+            self.SMB_SERVER_NAME, domain=self.SMB_DOMAIN, use_ntlm_v2=False)
+        try:
+            connect_result = connection.connect(server_ip, self.SMB_SERVER_PORT)
+            if connect_result is False:
+                raise ProtocolError("SMB Connection failure")
+        except ProtocolError as e:
+            self.logger.debug("Exception when connecting to %s: %s" % (self.SMB_SERVER_NAME, e))
+            raise exceptions.ConnectException(
+                "Connection to %s failed, wrong password?" % self.SMB_SERVER_NAME)
+        self.logger.debug('SMB Connection to %s successful!' % self.SMB_SERVER_NAME)
+        return connection
+
+    def dispose(self):
+        self.connection.close()
+
+    def create_local_digest(self, path):
+        # parse mtime to int (seconds) to avoid precision errors
+        mtime = int(os.path.getmtime(path))
+        return "%s-%s" % (os.path.getsize(path), mtime)
+
+    def create_remote_digest(self, path):
+        attributes = self.connection.getAttributes(self.SMB_SHARE_NAME, path)
+        # parse last_write_time to int (seconds) to avoid precision errors
+        mtime = int(attributes.last_write_time)
+        return "%s-%s" % (attributes.file_size, mtime)
+
+    def list_path(self, path):
+        path_listing = self.connection.listPath(self.SMB_SHARE_NAME, path)
+        files_folders = filter(lambda f: f.filename != '.' and f.filename != '..', path_listing)
+
+        def file_entry(f): return {'filename': f.filename, 'last_write_time': f.last_write_time}
+        directories = []
+        files = []
+        [directories.append(f.filename) if f.isDirectory else files.append(file_entry(f))
+            for f in files_folders]
+        return directories, files
+
+    def retrieve_file(self, remote_path, local_path):
+        with open(local_path, 'wb') as local_file:
+            self.connection.retrieveFile(self.SMB_SHARE_NAME, remote_path, local_file)
+            self.logger.debug('Downloading of file %s complete!' % remote_path)

--- a/openhsr_connect/sync.py
+++ b/openhsr_connect/sync.py
@@ -198,10 +198,11 @@ def sync_tree(connection, repo_name, source, destination, rel_path, excludes, ca
                                 (repo_name, relative_remote_path))
                     cache[filename] = cache_entry(create_local_digest(full_local_path))
                     is_existing_file = True
+                # rebuild cache entry from an old version with new structure if necessary
+                if 'hash' not in cache[filename]:
+                    cache[filename] = cache_entry(cache[filename])
                 if cache[filename]['ignore']:
                     continue
-                if 'hash' not in cache[filename]:  # For backwards compatibility
-                    cache[filename] = cache_entry(cache[filename])
                 if remote_digest == cache[filename]['hash']:
                     logger.debug(
                         '%s: File %s has not changed' % (repo_name, relative_remote_path))

--- a/openhsr_connect/sync.py
+++ b/openhsr_connect/sync.py
@@ -1,273 +1,215 @@
 import os
 from datetime import datetime
-import socket
 import logging
 import json
 import fnmatch
-from . import configuration
-from . import exceptions
-
-from smb.SMBConnection import SMBConnection
-from smb.smb_structs import ProtocolError
+import shutil
 
 
-SMB_SERVER_NAME = 'c206.hsr.ch'
-SMB_SHARE_NAME = 'skripte'
-SMB_DOMAIN = 'HSR'
-SMB_SERVER_PORT = 445
+class Sync:
+    """ Abstract Sync class, uses Template Method Pattern """
 
-logger = logging.getLogger('openhsr_connect.sync')
+    def __init__(self, config):
+        self.logger = logging.getLogger('openhsr_connect.sync')
+        self.config = config
+        self.connection = self.connect()
 
+    def connect(self):
+        """ return connection """
+        raise NotImplementedError()
 
-def smb_login(config):
-    username = config['login']['username']
-    password = configuration.get_password(config)
-    try:
-        server_ip = socket.gethostbyname(SMB_SERVER_NAME)
-    except OSError as e:
-        logger.debug("Exception when connecting to %s: %s" % (SMB_SERVER_NAME, e))
-        raise exceptions.ConnectException(
-            'Could not find %s, are you in the HSR network?' % SMB_SERVER_NAME)
+    def dispose(self):
+        """ dispose connection"""
+        pass
 
-    client_name = socket.gethostname()
-    connection = SMBConnection(
-        username, password, client_name,
-        SMB_SERVER_NAME, domain=SMB_DOMAIN, use_ntlm_v2=False)
-    try:
-        connect_result = connection.connect(server_ip, SMB_SERVER_PORT)
-        if connect_result is False:
-            raise ProtocolError("SMB Connection failure")
-    except ProtocolError as e:
-        logger.debug("Exception when connecting to %s: %s" % (SMB_SERVER_NAME, e))
-        raise exceptions.ConnectException(
-            "Connection to %s failed, wrong password?" % SMB_SERVER_NAME)
-    logger.debug('SMB Connection to %s successful!' % SMB_SERVER_NAME)
-    return connection
+    def create_local_digest(self, path):
+        raise NotImplementedError()
 
+    def create_remote_digest(self, path):
+        raise NotImplementedError()
 
-def load_cache(filename):
-    cache = {}
-    if os.path.exists(filename):
-        with open(filename, 'r') as fp:
-            cache = json.load(fp)
-    return cache
+    def retrieve_file(self, remote_path, local_path):
+        raise NotImplementedError()
 
+    def list_path(self, path):
+        """ Return a tuple with subdirectories and a list of files
 
-def dump_cache(filename, cache):
-    with open(filename, 'w') as fp:
-        json.dump(cache, fp)
+        A file is a dict with attributes filename, last_write_time
+        """
+        raise NotImplementedError()
 
+    def load_cache(self, filename):
+        cache = {}
+        if os.path.exists(filename):
+            with open(filename, 'r') as fp:
+                cache = json.load(fp)
+        return cache
 
-def exclude_file(path, filename, excludes):
-    full_name = '/' + path + '/' + filename
-    for exclude in excludes:
-        if exclude.startswith('/'):
-            if full_name.startswith(exclude):
+    def dump_cache(self, filename, cache):
+        with open(filename, 'w') as fp:
+            json.dump(cache, fp)
+
+    def cache_entry(self, digest, ignore=False):
+        return {'hash': digest, 'ignore': ignore}
+
+    def exclude_path(self, path, excludes):
+        filename = os.path.split(path)[1]
+        for exclude in excludes:
+            if exclude.startswith('/'):
+                if path.startswith(exclude[1:]):
+                    return True
+            elif '/' in exclude:
+                if exclude in path:
+                    return True
+            elif fnmatch.fnmatch(filename, exclude):
                 return True
-        elif '/' in exclude:
-            if exclude in full_name:
+        return False
+
+    def ask_question(self, question):
+        while True:
+            choice = input("%s (y/N)" % question)
+            choice = choice.lower()
+            if choice == '' or choice == 'n':
+                return False
+            elif choice == 'y':
                 return True
-        elif fnmatch.fnmatch(filename, exclude):
-            return True
-    return False
 
+    def get_copy_filename(self, path):
+        date = datetime.now().strftime("%y%m%d%H%M")
+        filename, extension = os.path.splitext(path)
+        return "%s-local-%s%s" % (filename, date, extension)
 
-def create_local_hash(filepath):
-    # parse mtime to int (seconds) to avoid precision errors
-    mtime = int(os.path.getmtime(filepath))
-    return "%s-%s" % (os.path.getsize(filepath), mtime)
+    def file_has_local_changes(self, local_path, current_digest):
+        return current_digest != self.create_local_digest(local_path)
 
-
-def create_remote_hash(shared_file):
-    # parse last_write_time to int (seconds) to avoid precision errors
-    mtime = int(shared_file.last_write_time)
-    return "%s-%s" % (shared_file.file_size, mtime)
-
-
-def timestamp_to_int(old_hash):
-    digest = old_hash.split('-')
-    time = int(float(digest[1]))
-    return '%s-%s' % (digest[0], time)
-
-
-def file_has_local_changes(filepath, remote_hash):
-    return remote_hash != create_local_hash(filepath)
-
-
-def handle_local_change(full_local_path, rel_remote_path, config):
-    logger.debug('File %s has changed locally or it has been added to the index' % rel_remote_path)
-    handling_config = config['local-changes']
-    if handling_config == 'keep':
-        return 'keep'
-    elif handling_config == 'ask':
-        question = "Do you want to overwrite %s with the version from the server?"
-        if not ask_question(question % full_local_path):
+    def handle_local_change(self, full_local_path, rel_remote_path):
+        self.logger.debug('File %s has changed locally or it has been added to the index' % rel_remote_path)
+        handling_config = self.config['sync']['conflict-handling']['local-changes']
+        if handling_config == 'keep':
             return 'keep'
-        logger.debug("File %s will be overwritten" % full_local_path)
-        return 'overwrite'
-    elif handling_config == 'overwrite':
-        logger.info("File %s will be overwritten" % full_local_path)
-        return 'overwrite'
-    elif handling_config == 'makeCopy':
-        new_filename = get_copy_filename(full_local_path)
-        logger.debug("Rename local file %s to %s" % (full_local_path, new_filename))
-        os.rename(full_local_path, new_filename)
-        return 'makeCopy'
-    return 'keep'  # just in case a wrong config is given
+        elif handling_config == 'ask':
+            question = "Do you want to overwrite %s with the version from the server?"
+            if not self.ask_question(question % full_local_path):
+                return 'keep'
+            self.logger.debug("File %s will be overwritten" % full_local_path)
+            return 'overwrite'
+        elif handling_config == 'overwrite':
+            self.logger.info("File %s will be overwritten" % full_local_path)
+            return 'overwrite'
+        elif handling_config == 'makeCopy':
+            new_filename = self.get_copy_filename(full_local_path)
+            self.logger.debug("Rename local file %s to %s" % (full_local_path, new_filename))
+            os.rename(full_local_path, new_filename)
+            return 'makeCopy'
+        return 'keep'  # just in case a wrong config is given
 
-
-def handle_deleted_files(fileset, repo_name, rel_path, destination, cache, config_handling):
-    for filename in fileset:
-        cache[filename] = cache[filename] if 'hash' in cache[filename] \
-                            else cache_entry(cache[filename])
-        if cache[filename]['ignore']:
-            continue
-        relative_path = os.path.join(rel_path, filename)
-        full_path = os.path.join(destination, relative_path)
-        logger.debug('%s: %s has been deleted on remote' % (repo_name, relative_path))
-        if os.path.exists(full_path):
-            if config_handling == 'ask':
-                question = ("%s has been deleted on remote. "
-                            "Do you want to delete your local copy?")
-                answer = ask_question(question % os.path.join(repo_name, relative_path))
-                if answer is False:
+    def handle_deleted_files(self, fileset, repo_name, rel_path, destination, cache):
+        for filename in fileset:
+            if 'ignore' in cache[filename] and cache[filename]['ignore']:
+                continue
+            relative_path = os.path.join(rel_path, filename)
+            full_path = os.path.join(destination, relative_path)
+            self.logger.debug('%s: %s has been deleted on remote' % (repo_name, relative_path))
+            if os.path.exists(full_path):
+                conflict_handling = self.config['sync']['conflict-handling']['remote-deleted']
+                if conflict_handling == 'ask':
+                    question = ("%s has been deleted on remote. "
+                                "Do you want to delete your local copy?")
+                    answer = self.ask_question(question % os.path.join(repo_name, relative_path))
+                    if answer is False:
+                        cache[filename]['ignore'] = True
+                        continue
+                elif conflict_handling != 'delete':
                     cache[filename]['ignore'] = True
                     continue
-            elif config_handling != 'delete':
-                cache[filename]['ignore'] = True
+
+                self.logger.info('%s: %s will be removed' % (repo_name, relative_path))
+                os.remove(full_path) if os.path.isfile(full_path) else shutil.rmtree(full_path)
+                del cache[filename]
+
+    def sync_tree(self, repo_name, source, destination, rel_path, excludes, cache):
+        fileset = set(cache)
+        remote_path = os.path.join(source, rel_path)
+        remote_directories, remote_files = self.list_path(remote_path)
+        for remote_dir in remote_directories:
+            fileset.discard(remote_dir)
+            relative_remote_path = os.path.join(rel_path, remote_dir)
+            if self.exclude_path(relative_remote_path, excludes):
+                self.logger.debug('%s: Skipping ignored folder: %s' % (repo_name, relative_remote_path))
                 continue
-
-            logger.info('%s: %s will be removed' % (repo_name, relative_path))
-            remove_tree(full_path)
-            del cache[filename]
-
-
-def ask_question(question):
-    while True:
-        choice = input("%s (y/N)" % question)
-        choice = choice.lower()
-        if choice == '' or choice == 'n':
-            return False
-        elif choice == 'y':
-            return True
-
-
-def download_file(connection, remote, local):
-    logger.info('Downloading file %s' % remote)
-    with open(local, 'wb') as local_file:
-        connection.retrieveFile(SMB_SHARE_NAME, remote, local_file)
-        logger.debug('Downloading of file %s complete!' % remote)
-
-
-def get_copy_filename(path):
-    date = datetime.now().strftime("%y%m%d%H%M")
-    filename, extension = os.path.splitext(path)
-    return "%s-local-%s%s" % (filename, date, extension)
-
-
-def remove_tree(filepath):
-    if os.path.isfile(filepath):
-        os.remove(filepath)
-    else:
-        for subfile in os.listdir(filepath):
-            remove_tree(os.path.join(filepath, subfile))
-        os.rmdir(filepath)
-
-
-def cache_entry(digest, ignore=False):
-    return {'hash': digest, 'ignore': ignore}
-
-
-def sync_tree(connection, repo_name, source, destination, rel_path, excludes, cache, config):
-    fileset = set(cache)
-    remote_path = os.path.join(source, rel_path)
-    for shared_file in connection.listPath(SMB_SHARE_NAME, remote_path):
-        filename = shared_file.filename
-        fileset.discard(filename)
-        relative_remote_path = os.path.join(rel_path, filename)
-        full_local_path = os.path.join(destination, rel_path, filename)
-        if filename == '.' or filename == '..':
-            continue
-        elif exclude_file(rel_path, filename, excludes):
-            logger.debug('%s: Skipping ignored file: %s' % (repo_name, relative_remote_path))
-            continue
-        elif shared_file.isDirectory:
+            full_local_path = os.path.join(destination, rel_path, remote_dir)
             if not os.path.exists(full_local_path):
-                logger.debug('Creating missing directory %s' % full_local_path)
+                self.logger.debug('Creating missing directory %s' % full_local_path)
                 os.makedirs(full_local_path)
+            if remote_dir not in cache:
+                cache[remote_dir] = {}
+            # recursive call to sync the subfolder
+            self.sync_tree(
+                repo_name, source, destination,
+                os.path.join(rel_path, remote_dir), excludes,
+                cache[remote_dir])
 
-            if filename not in cache:
-                cache[filename] = {}
-            sync_tree(
-                connection, repo_name, source, destination,
-                os.path.join(rel_path, filename), excludes,
-                cache[filename], config)
-        else:
-            remote_hash = create_remote_hash(shared_file)
+        for remote_file in remote_files:
+            filename = remote_file['filename']
+            fileset.discard(filename)
+            relative_remote_path = os.path.join(rel_path, filename)
+            full_remote_path = os.path.join(remote_path, filename)
+            full_local_path = os.path.join(destination, rel_path, filename)
+            if self.exclude_path(relative_remote_path, excludes):
+                self.logger.debug('%s: Skipping ignored file: %s' % (repo_name, relative_remote_path))
+                continue
+            remote_digest = self.create_remote_digest(full_remote_path)
             if os.path.exists(full_local_path):
                 is_existing_file = False
                 if filename not in cache:
                     # already existing local file
-                    logger.info('%s: Add existing file to index: %s' %
-                                (repo_name, relative_remote_path))
-                    cache[filename] = cache_entry(create_local_hash(full_local_path))
+                    self.logger.info('%s: Add existing file to index: %s' %
+                                     (repo_name, relative_remote_path))
+                    cache[filename] = self.cache_entry(self.create_local_digest(full_local_path))
                     is_existing_file = True
-                # rebuild cache entry from an old version with new structure if necessary
-                if 'hash' not in cache[filename]:
-                    # convert timestamp to int, old timestamps were floats
-                    digest = timestamp_to_int(cache[filename])
-                    cache[filename] = cache_entry(digest)
                 if cache[filename]['ignore']:
                     continue
-                if remote_hash == cache[filename]['hash']:
-                    logger.debug(
+                if remote_digest == cache[filename]['hash']:
+                    self.logger.debug(
                         '%s: File %s has not changed' % (repo_name, relative_remote_path))
                     continue
-                if file_has_local_changes(full_local_path, cache[filename]['hash']) \
+                if self.file_has_local_changes(full_local_path, cache[filename]['hash']) \
                         or is_existing_file:
-                    handling_result = handle_local_change(
-                        full_local_path, relative_remote_path,
-                        config['conflict-handling'])
+                    handling_result = self.handle_local_change(
+                        full_local_path, relative_remote_path)
                     if handling_result == 'keep':
                         cache[filename]['ignore'] = True
                         continue
 
-            cache[filename] = cache_entry(remote_hash)
-            full_remote_path = os.path.join(remote_path, filename)
-            download_file(connection, full_remote_path, full_local_path)
+            cache[filename] = self.cache_entry(remote_digest)
+
+            self.logger.info('Downloading file %s' % full_remote_path)
+            self.retrieve_file(full_remote_path, full_local_path)
 
             # set last write time to that of the remote file
             os.utime(
                 full_local_path,
-                (shared_file.last_access_time, shared_file.last_write_time))
+                (remote_file['last_write_time'], remote_file['last_write_time']))
 
-    if fileset:  # if fileset not empty, remote files / folders have been deleted
-        handle_deleted_files(fileset, repo_name, rel_path, destination, cache,
-                             config['conflict-handling']['remote-deleted'])
+        if fileset:  # if fileset not empty, remote files / folders have been deleted
+            self.handle_deleted_files(fileset, repo_name, rel_path, destination, cache)
 
+    def sync(self):
+        repositories = self.config['sync']['repositories']
+        if not repositories:
+            self.logger.info("No repositories in config")
+        for name, repository in repositories.items():
+            source = repository['remote-dir']
+            destination = os.path.expanduser(repository['local-dir'])
+            if not os.path.exists(destination):
+                os.makedirs(destination)
+            self.logger.info('Starting sync: %s -> %s' % (source, destination))
+            excludes = self.config['sync']['global-exclude'] + repository['exclude']
+            self.logger.info('The following patterns will be excluded: %s' % (excludes))
+            cache_file = '%s/.%s.json' % (destination, name)
+            cache = self.load_cache(cache_file)
+            self.sync_tree(name, source, destination, '', excludes, cache)
+            self.dump_cache(cache_file, cache)
+            self.logger.info("Sync of %s completed" % name)
 
-def sync(config):
-    connection = smb_login(config)
-    repositories = config['sync']['repositories']
-    if not repositories:
-        logger.info("No repositories in config")
-    for name, repository in repositories.items():
-        source = repository['remote-dir']
-        destination = repository['local-dir']
-        if not os.path.exists(destination):
-            os.makedirs(destination)
-        logger.info('Starting sync: %s -> %s' % (source, destination))
-        excludes = config['sync']['global-exclude'] + repository['exclude']
-        logger.info('The following patterns will be excluded: %s' % (excludes))
-        cache_file = '%s/.%s.json' % (destination, name)
-        cache = load_cache(cache_file)
-        sync_tree(connection, name, source, destination, '', excludes, cache, config['sync'])
-        dump_cache(cache_file, cache)
-        logger.info("Sync of %s completed" % name)
-
-    connection.close()
-
-
-if __name__ == "__main__":
-    config = configuration.load_config()
-    sync(config)
+        self.dispose()

--- a/openhsr_connect/sync.py
+++ b/openhsr_connect/sync.py
@@ -205,6 +205,7 @@ def sync_tree(connection, repo_name, source, destination, rel_path, excludes, ca
         else:
             remote_hash = create_remote_hash(shared_file)
             if os.path.exists(full_local_path):
+                is_existing_file = False
                 if filename not in cache:
                     # already existing local file
                     logger.info('%s: Add existing file to index: %s' %


### PR DESCRIPTION
Wie in #4 von @murieletrentini erwähnt, werden bisher existierende Dateien beim ersten Sync überschrieben, z.B. weil man bereits einen Sync-Ordner mit den Files vom Skripte-Server erstellt hat.

Mit diesem PR werden Dateien, die nicht im Cache sind, aufgenommen (sofern sie auch auf dem Skripte-Server vorkommen). Sollte die Version auf dem Server unterschiedlich sein, wird entsprechend der Konflikt-Auflösung für `local-changes` vorgegangen.

Neu werden Dateien, die nicht überschrieben werden sollen, mit einem Ignore-Flag im Cache markiert.

Zusätzlich ist nun die Sync-Logik von der spezifischen Implementation für SMB getrennt. So kann auch ein anderes back-end wie Moodle implementiert werden