### PR TITLE
Don't do pokemon exception handling

### DIFF
--- a/openhsr_connect/__main__.py
+++ b/openhsr_connect/__main__.py
@@ -7,6 +7,7 @@ from openhsr_connect import configuration
 from openhsr_connect import user_daemon
 from openhsr_connect import smb_sync
 from openhsr_connect import __VERSION__
+from openhsr_connect import exceptions
 
 logger = logging.getLogger('openhsr_connect')
 
@@ -88,7 +89,7 @@ def main():
         cli.add_command(edit)
         cli.add_command(browserhelp)
         cli(standalone_mode=False)
-    except Exception as e:
+    except (exceptions.Error, click.ClickException) as e:
         logger.error(e)
         logger.debug(e, exc_info=True)
         exit(1)

--- a/openhsr_connect/exceptions.py
+++ b/openhsr_connect/exceptions.py
@@ -1,14 +1,18 @@
-class ConnectException(Exception):
+class Error(Exception):
     pass
 
 
-class PrintException(ConnectException):
+class ConnectException(Error):
     pass
 
 
-class PasswordException(ConnectException):
+class PrintException(Error):
     pass
 
 
-class ConfigurationException(ConnectException):
+class PasswordException(Error):
+    pass
+
+
+class ConfigurationException(Error):
     pass


### PR DESCRIPTION
"Gotta catch 'em all" does not apply to exceptions. Just got a crash here, and
the output is not what we'd want to get as part of an issue, or helpful to the
user in any way:

    The following patterns will be excluded: ['.DS_Store', 'Thumbs.db']
    string indices must be integers

Instead, add a new exception base class for errors which are not bugs, and only
catch those.

This also stops everything from inheriting ConnectException - I don't see why a
Print- or ConfigurationException should be a ConnectException.