### PR TITLE
Change cache path

### DIFF
--- a/openhsr_connect/sync.py
+++ b/openhsr_connect/sync.py
@@ -207,7 +207,7 @@ class Sync:
             self.logger.info('Starting sync: %s -> %s' % (source, destination))
             excludes = self.config['sync']['global-exclude'] + repository['exclude']
             self.logger.info('The following patterns will be excluded: %s' % (excludes))
-            cache_file = '%s/.%s.json' % (destination, name)
+            cache_file = os.path.join(destination, '.openhsr-%s.json' % name)
             cache = self.load_cache(cache_file)
             self.sync_tree(name, source, destination, '', excludes, cache)
             self.dump_cache(cache_file, cache)


### PR DESCRIPTION
This serves two purposes:

- Don't crash when an old cache file (from before the sync refactoring) is
  around
- Make it more clear where the file is coming from by adding `openhsr` to its
  name.