### PR TITLE
 Remove discrimination against dash containing names

### DIFF
--- a/openhsr_connect/configuration.py
+++ b/openhsr_connect/configuration.py
@@ -37,7 +37,7 @@ SCHEMA = {
                 },
                 'email': {
                     'type': 'string',
-                    'pattern': '^[a-zA-Z0-9]+\.[a-zA-Z0-9]+\@hsr.ch$'
+                    'pattern': '^[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+\@hsr.ch$'
                 }
             },
             'required': ['username', 'email']


### PR DESCRIPTION
regex didn't allow names containing a dash such as my own..