### PR TITLE
Switch pyup update schedule to monthly

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,1 @@
+schedule: "every month"


### PR DESCRIPTION
Right now we don't have any tests running on CI anyways, so the requirement pinning doesn't make too much sense (apart from being prepared for the future). Let's switch pyup to a monthly batched update (see [docs](https://pyup.io/docs/configuration/)) so we get less PR noise.